### PR TITLE
fixing issue in firefox

### DIFF
--- a/css/vfb/layout/header.css
+++ b/css/vfb/layout/header.css
@@ -52,3 +52,7 @@ a {
 a:hover{
 	text-decoration:underline;
 }
+
+img:-moz-loading {
+    visibility: hidden;
+}


### PR DESCRIPTION
Disables the mozilla 'feature' that displays an image frame and title before the image has loaded.
fixes #32 
