### PR TITLE
fix link to JFRC2 registered fruitless clones

### DIFF
--- a/site/vfb_site/image_data_downloads.htm
+++ b/site/vfb_site/image_data_downloads.htm
@@ -48,7 +48,7 @@
 		<h3>Fruitless neuroblast clones from Cachero/Ostrovsky (Jefferis Group)</h3>
 		
 		<p>
-		JFRC2 registered images of the fruitless neuroblast clones are provided <a href="http://flybrain.mrc-lmb.cam.ac.uk/CacheroOstrovsky/Data/ExtractedClonesFullSize/" target="_new">here</a>.</p>
+		JFRC2 registered images of the fruitless neuroblast clones are provided <a href="http://flybrain.mrc-lmb.cam.ac.uk/vfb/nbfru" target="_new">here</a>.</p>
 		<p> Both male and female versions are provided regardless of whether a sexual dimorphism was observed. The data were cross-registered against the JFRC2 template by applying <a href="https://github.com/jefferislab/BridgingRegistrations/tree/94dd5e4f54cf9918d26c62aa2a582d2cbafa1fe6/JFRC2_IS2.list" target="_new">JFRC2_IS2 bridging registration</a>. The original data (registered against IS2 template) are available <a href="http://flybrain.mrc-lmb.cam.ac.uk/CacheroOstrovsky/Data/ExtractedClonesFullSize/" target="_new">here</a>.
 			</p>
 			


### PR DESCRIPTION
- was still pointing to IS2 registered data
- fixes #195
