### PR TITLE
Point the README at the MCP server and the current repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+> **Looking for the VFB MCP server?** It lives at [VirtualFlyBrain/VFB3-MCP](https://github.com/VirtualFlyBrain/VFB3-MCP) and is hosted at `https://vfb3-mcp.virtualflybrain.org`:
+>
+> ```bash
+> claude mcp add --transport http virtual-fly-brain https://vfb3-mcp.virtualflybrain.org
+> ```
+>
+> This repository holds the original VFB server code and community documentation. The current web application is [geppetto-vfb](https://github.com/VirtualFlyBrain/geppetto-vfb), the documentation site is [VFB2](https://github.com/VirtualFlyBrain/VFB2), and the Python client is [VFB_connect](https://github.com/VirtualFlyBrain/VFB_connect).
+
 Main:
 [![Build Status](https://travis-ci.org/VirtualFlyBrain/VFB.svg?branch=Main-Server)](https://travis-ci.org/VirtualFlyBrain/VFB)
 Backup:


### PR DESCRIPTION
This repository still ranks well in search for "Virtual Fly Brain" but its README describes the original VFB server, with dead Travis and Waffle badges and no pointer to anything current. Anyone — or any assistant — landing here has no route to the MCP server, the current web application or the Python client.

Adds a short block above the existing content: where the MCP server lives, its one-line install command, and where the web application (`geppetto-vfb`), documentation site (`VFB2`) and Python client (`VFB_connect`) are. Nothing else is changed.

Committed through the contents API because the PAT used has no `workflow` scope and pushing a new ref carries `.github/workflows/builder-image.yml`.
